### PR TITLE
fix: issue #2 search by relation slug

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,28 @@ Return a hierarchical tree structure of comments for specified instance of Conte
 ]
 ```
 
+### Get Comments (flat structure)
+
+`GET <host>/comments/<content-type>:<id>/flat`
+
+Return a flat structure of comments for specified instance of Content Type like for example `Article` with `ID: 1`
+
+**Example URL**: `https://localhost:1337/comments/article:1/flat`
+
+**Example response body**
+
+```
+[
+    {
+        -- Comment Model fields ---
+    },
+    {
+        -- Comment Model fields ---
+    },
+    ...
+]
+```
+
 **Possible response codes**
 - `200` - Successful. Response with list of comments (can be empty)
 - `400` - Bad Request. Requested list for not valid / not existing Content Type

--- a/config/routes.json
+++ b/config/routes.json
@@ -17,6 +17,14 @@
       }
     },
     {
+      "method": "GET",
+      "path": "/:relation/flat",
+      "handler": "comments.findAllFlat",
+      "config": {
+        "policies": []
+      }
+    },
+    {
       "method": "PUT",
       "path": "/:relation/comment/:commentId",
       "handler": "comments.put",

--- a/controllers/comments.js
+++ b/controllers/comments.js
@@ -32,6 +32,17 @@ module.exports = {
     return await strapi.plugins.comments.services.comments.findAll(ctx.query, page)
   },
 
+  findAllFlat: async (ctx) => {
+    const { params = {} } = ctx;
+    const { relation } = parseParams(params);
+    try {
+      return await strapi.plugins.comments.services.comments.findAllFlat(relation);
+    }
+    catch (e) {
+      throwError(ctx, e);
+    }
+  },
+
   findAllInHierarchy: async (ctx) => {
     const { params = {} } = ctx;
     const { relation } = parseParams(params);

--- a/models/comment.settings.json
+++ b/models/comment.settings.json
@@ -60,6 +60,11 @@
       "type": "string",
       "configurable": false
     },
+    "relatedSlug": {
+      "type": "string",
+      "private": true,
+      "configurable": false
+    },
     "related": {
       "collection": "*",
       "filter": "field",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-plugin-comments",
-  "version": "1.0.0-beta.0",
+  "version": "1.0.0-beta.1",
   "description": "Strapi - Comments plugin",
   "strapi": {
     "name": "Comments",


### PR DESCRIPTION
### What has been done?

Introducing the relation slug to be able to search by it, instead of sync searching with lodash.

Fix: Issue #2 

### How to test it?
1. Add comment with proper relation
2. See that relation is still visible in moderation mode & in the endpoint payload