### PR TITLE
fix: filtering only root level

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-plugin-comments",
-  "version": "1.0.1-beta.4",
+  "version": "1.0.1-beta.5",
   "description": "Strapi - Comments plugin",
   "strapi": {
     "name": "Comments",


### PR DESCRIPTION
## Fixes
- Based on comment in #25, filters & query are now applied only to the root level of comments.