### PR TITLE
fix: compatibility with strapi 3.6.x

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+## Ticket
+
+https://github.com/VirtusLab/strapi-plugin-comments/issues/-<your-ticket-#>
+
+## Summary
+
+What does this PR do/solve? 
+
+> PRs should be as small as they need to be, if this section starts becoming a novel you should _seriously_ consider breaking it up into multiple PRs
+
+## Test Plan
+
+How are you testing the work you're submitting?

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Complete installation requirements are exact same as for Strapi itself and can b
 
 **Supported Strapi versions**:
 
-- Strapi v3.5.3 (recently tested)
+- Strapi v3.6.0 (recently tested)
 - Strapi v3.x
 
 (This plugin may work with the older Strapi versions, but these are not tested nor officially supported at this time.)

--- a/config/functions/bootstrap.js
+++ b/config/functions/bootstrap.js
@@ -44,5 +44,5 @@ module.exports = async () => {
   ];
 
   const { actionProvider } = strapi.admin.services.permission;
-  actionProvider.register(actions);
+  await actionProvider.registerMany(actions);
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-plugin-comments",
-  "version": "1.0.1-beta.7",
+  "version": "1.0.1",
   "description": "Strapi - Comments plugin",
   "strapi": {
     "name": "Comments",
@@ -26,8 +26,8 @@
     "reactstrap": "8.4.1",
     "redux-saga": "^0.16.0",
     "request": "^2.83.0",
-    "strapi-helper-plugin": "3.5.3",
-    "strapi-utils": "3.5.3",
+    "strapi-helper-plugin": "3.6.0",
+    "strapi-utils": "3.6.0",
     "uuid": "^3.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab/strapi-plugin-comments/issues/49

## Summary

What does this PR do/solve? 

Changes bootstrap method to be compatible with `Strapi 3.6.x`

## Test Plan

N/A
